### PR TITLE
Turn off Mirage in development

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -23,7 +23,11 @@ module.exports = function(environment) {
     },
 
     API: {
-      host: ''
+      host: 'https://conduit.productionready.io'
+    },
+
+    'ember-cli-mirage': {
+      enabled: false
     },
   };
 
@@ -52,9 +56,6 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     // Some prod-only config
-    ENV.API = {
-      host: 'https://conduit.productionready.io'
-    };
   }
 
   return ENV;


### PR DESCRIPTION
Fixes #47 

Turns off Mirage in development but leaves it enabled for tests