### PR TITLE
Split user model into user and profile

### DIFF
--- a/app/models/article.js
+++ b/app/models/article.js
@@ -49,7 +49,7 @@ export default DS.Model.extend({
   /**
    * @property {belongsToModel} author
    */
-  author: belongsTo('user'),
+  author: belongsTo('profile'),
 
   /**
    * @property {boolean} favorited

--- a/app/models/profile.js
+++ b/app/models/profile.js
@@ -1,0 +1,14 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  bio: DS.attr('string'),
+  image: DS.attr('string'),
+  following: DS.attr('boolean'),
+  articles: DS.hasMany('article', { async: false, inverse: 'author' }),
+  loadArticles() {
+    return this.store.query('article', { author: this.id }).then(articles => {
+      this.set('articles', articles);
+      return articles;
+    });
+  },
+});

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,34 +1,13 @@
 import DS from 'ember-data';
 
-const { attr } = DS;
-
 export default DS.Model.extend({
-  /**
-   * @property {string} username
-   */
-  username: attr('string'),
-
-  /**
-   * @property {string} email
-   */
-  email: attr('string'),
-
-  /**
-   * @property {string} bio
-   */
-  bio: attr('string'),
-
-  /**
-   * @property {string} image
-   */
-  image: attr('string'),
-
-  /**
-   * @property {boolean} following
-   */
-  following: attr('boolean'),
-
-  // Only needed for authenticating users
-  password: attr('string'),
-  token: attr('string'),
+  username: DS.attr('string'),
+  email: DS.attr('string'),
+  bio: DS.attr('string'),
+  image: DS.attr('string'),
+  following: DS.attr('boolean'),
+  password: DS.attr('string'),
+  token: DS.attr('string'),
+  createdAt: DS.attr('string'),
+  updatedAt: DS.attr('string'),
 });

--- a/app/router.js
+++ b/app/router.js
@@ -12,7 +12,7 @@ Router.map(function() {
   this.route('login');
   this.route('register');
 
-  this.route('profile', { path: '/profile/:username' }, function() {
+  this.route('profile', { path: '/profile/:id' }, function() {
     this.route('favorites');
   });
   this.route('settings');

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,10 +1,7 @@
 import Route from '@ember/routing/route';
-import { hash } from 'rsvp';
 
 export default Route.extend({
-  model(params) {
-    return hash({
-      user: this.store.findRecord('user', params.username),
-    });
+  model({ id }) {
+    return this.store.findRecord('profile', id);
   },
 });

--- a/app/routes/profile/index.js
+++ b/app/routes/profile/index.js
@@ -1,12 +1,8 @@
 import Route from '@ember/routing/route';
-import { hash } from 'rsvp';
 
 export default Route.extend({
-  model(/*params*/) {
-    return hash({
-      articles: this.store.query('article', {
-        author: this.modelFor('profile').user.get('username'),
-      }),
-    });
+  model() {
+    const profile = this.modelFor('profile');
+    return profile.loadArticles().then(() => profile);
   },
 });

--- a/app/serializers/profile.js
+++ b/app/serializers/profile.js
@@ -1,0 +1,10 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  primaryKey: 'username',
+  normalizeFindRecordResponse(store, primaryModelClass, payload) {
+    payload.profiles = payload.profile;
+    delete payload.profile;
+    return this._super(...arguments);
+  },
+});

--- a/app/serializers/user.js
+++ b/app/serializers/user.js
@@ -1,5 +1,15 @@
 import DS from 'ember-data';
 
 export default DS.RESTSerializer.extend({
-  primaryKey: 'username',
+  attrs: {
+    token: {
+      serialize: false,
+    },
+    createdAt: {
+      serialize: false,
+    },
+    updatedAt: {
+      serialize: false,
+    },
+  },
 });

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -65,7 +65,7 @@ export default Service.extend({
             users: [userPayload.user],
           });
           this.setToken(userPayload.user.token);
-          this.set('user', this.store.peekRecord('user', userPayload.user.username));
+          this.set('user', this.store.peekRecord('user', userPayload.user.id));
           return this.user;
         }
       });

--- a/app/templates/components/feed-item.hbs
+++ b/app/templates/components/feed-item.hbs
@@ -1,12 +1,11 @@
 <div class="article-preview" data-test-article-preview>
   <div class="article-meta">
-    {{#link-to "profile" article.author.username}}
-      <img data-test-article-author-image src={{article.author.image}}
-        alt="profile image for {{article.author.username}}">
+    {{#link-to "profile" article.author.id}}
+      <img data-test-article-author-image src={{article.author.image}} alt="profile image for {{article.author.id}}">
     {{/link-to}}
     <div class="info">
-      {{#link-to "profile" article.author.username class="author" data-test-article-author-username=article.author.username}}
-        {{article.author.username}}
+      {{#link-to "profile" article.author.id class="author" data-test-article-author-username=article.author.id}}
+        {{article.author.id}}
       {{/link-to}}
       <span class="date" data-test-article-date>{{moment-format article.createdAt "MMM D, YYYY"}}</span>
     </div>

--- a/mirage/factories/profile.js
+++ b/mirage/factories/profile.js
@@ -1,0 +1,19 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  token: 'auth-token',
+
+  image: null,
+
+  email() {
+    return faker.internet.email();
+  },
+
+  username() {
+    return faker.internet.userName();
+  },
+
+  bio() {
+    return faker.lorem.paragraph();
+  },
+});

--- a/mirage/models/profile.js
+++ b/mirage/models/profile.js
@@ -1,0 +1,3 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({});

--- a/tests/integration/components/feed-item-test.js
+++ b/tests/integration/components/feed-item-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | feed item', function(hooks) {
     const article = {
       author: {
         image: 'https://static.productionready.io/images/smiley-cyrus.jpg',
-        username: 'Alon Bukai',
+        id: 'AlonBukai',
       },
       createdAt: moment('1995-12-25'),
       favoritesCount: 9000,
@@ -32,8 +32,8 @@ module('Integration | Component | feed item', function(hooks) {
       .hasAttribute('src', 'https://static.productionready.io/images/smiley-cyrus.jpg', 'Image is default image');
 
     assert
-      .dom(`[data-test-article-author-username="${article.author.username}"]`)
-      .hasText('Alon Bukai', 'Author name is correct');
+      .dom(`[data-test-article-author-username="${article.author.id}"]`)
+      .hasText('AlonBukai', 'Author name is correct');
 
     assert.dom('[data-test-article-date]').hasText('Dec 25, 1995', 'Date is correct');
 


### PR DESCRIPTION
Fixes https://github.com/gothinkster/ember-realworld/issues/49

Splits the single user model into two separate models each with their own concerns:

1. `user` - The current user. Can be used to tell if a user is logged in or not. Can be used on the settings page to edit a user's properties. Can grab the logged in user's article feed.
2. `profile` - Similar to a user but more to do with authors of articles. They can be followed, have their articles favorited/unfavorited.

Also profile page isn't properly implemented yet so I'm going to punt on tests for that page for now. 