### PR TITLE
Fix flakey spec

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -34,7 +34,7 @@ export default function() {
 
   this.get('/tags', () => {
     return {
-      tags: ['emberjs', 'tomster', 'wycats', 'tomdale', 'ember-cli'],
+      tags: ['emberjs', 'tomster', 'wycats', 'tomdale', 'ember-cli', 'training', 'dragons'],
     };
   });
 }

--- a/mirage/factories/article.js
+++ b/mirage/factories/article.js
@@ -1,6 +1,6 @@
 import { Factory, association, faker } from 'ember-cli-mirage';
 
-const tags = ['dragons', 'training', 'emberjs', 'wycats', 'tomdale', 'tomster'];
+const tags = ['emberjs', 'tomster', 'wycats', 'tomdale', 'ember-cli', 'training', 'dragons'];
 
 export default Factory.extend({
   author: association(),


### PR DESCRIPTION
Fixes the flakey spec encountered in #69 

The problem here was that we didn't have a consistent set of tags shared between `/tags` endpoint and as a relationship on article models. This became an issue as we randomly pluck tags from the tags array and assign them to articles.

This meant if tags which weren't included in the response from the `/tags` endpoint were added as tags to articles, the number would deviate from 7 tags.

By making both sets of tags consistent the number should always stay the same.