### PR TITLE
Move tags to a component and load async

### DIFF
--- a/app/components/tag-list.js
+++ b/app/components/tag-list.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+  store: service(),
+  init() {
+    this._super(...arguments);
+    this.set('tags', []);
+    this.loadTags.perform();
+  },
+  loadTags: task(function*() {
+    const tags = yield this.store.findAll('tag', { reload: true });
+    this.set('tags', tags);
+  }).drop(),
+});

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -1,22 +1,11 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
 import { oneWay } from '@ember/object/computed';
 
 export default Controller.extend({
-  session: service(),
   queryParams: ['tag', 'page'],
   tag: null,
   page: 1,
 
   totalPages: oneWay('model.articles.meta.articlesCount'),
   postsPerPage: oneWay('model.perPage'),
-
-  actions: {
-    setTag(value) {
-      if (this.tag !== value) {
-        this.set('page', 1);
-      }
-      this.set('tag', value);
-    },
-  },
 });

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -15,7 +15,6 @@ export default Route.extend({
     const perPage = 10;
     return hash({
       perPage: perPage,
-      popularTags: this.store.findAll('tag'),
       articles: this.store.query('article', {
         tag: params.tag,
         limit: 10,

--- a/app/templates/components/tag-list.hbs
+++ b/app/templates/components/tag-list.hbs
@@ -1,0 +1,16 @@
+<p>Popular Tags</p>
+{{#if this.loadTags.isRunning}}
+  <p>Loading...</p>
+{{else}}
+  <div class="tag-list">
+    {{#each this.tags as |tag| }}
+      {{#link-to "home"
+        (query-params author=null tag=tag.id page=1)
+        class="tag-pill tag-default"
+        data-test-tag=tag.id
+      }}
+        {{tag.id}}
+      {{/link-to}}
+    {{/each}}
+  </div>
+{{/if}}

--- a/app/templates/home.hbs
+++ b/app/templates/home.hbs
@@ -36,12 +36,7 @@
       </div>
       <div class="col-md-3">
         <div class="sidebar">
-          <p>Popular Tags</p>
-          <div class="tag-list">
-            {{#each model.popularTags as |tag|}}
-              <a href="" class="tag-pill tag-default" {{action "setTag" tag.value}} data-test-tag-item>{{tag.value}}</a>
-            {{/each}}
-          </div>
+          {{tag-list}}
         </div>
       </div>
     </div>

--- a/tests/acceptance/home-test.js
+++ b/tests/acceptance/home-test.js
@@ -16,7 +16,7 @@ module('Acceptance | home', function(hooks) {
 
     assert.equal(currentURL(), '/');
     assert.equal(this.element.querySelectorAll('[data-test-article-preview]').length, 10);
-    assert.equal(this.element.querySelectorAll('[data-test-tag-item]').length, 7);
+    assert.equal(this.element.querySelectorAll('[data-test-tag]').length, 7);
     assert.equal(this.element.querySelectorAll('[data-test-page-link]').length, 2);
     assert.equal(this.element.querySelectorAll('.feed-toggle a.nav-link').length, 1);
     assert.dom('.feed-toggle a.nav-link.active').hasText('Global Feed');
@@ -48,12 +48,12 @@ module('Acceptance | home', function(hooks) {
 
     await visit('/');
     await click('.sidebar .tag-list a:first-child');
-    await click('ul.pagination .page-item:nth-child(2) a');
+    await click('[data-test-tag="training"]');
 
-    assert.equal(currentURL(), '/?page=2&tag=emberjs');
+    assert.equal(currentURL(), '/?tag=training');
     assert.equal(this.element.querySelectorAll('.feed-toggle a.nav-link').length, 2);
-    assert.dom('.feed-toggle a.nav-link.active').hasText('emberjs');
-    assert.dom('ul.pagination .page-item.active a').hasText('2');
+    assert.dom('.feed-toggle a.nav-link.active').hasText('training');
+    assert.dom('ul.pagination .page-item.active a').hasText('1');
   });
 
   test('resetting to the main list', async function(assert) {

--- a/tests/integration/components/tag-list-test.js
+++ b/tests/integration/components/tag-list-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Integration | Component | tag-list', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('it loads the tags', async function(assert) {
+    await render(hbs`{{tag-list}}`);
+    assert.dom('[data-test-tag]').exists({ count: 7 }, 'All the tags appear');
+  });
+});


### PR DESCRIPTION
Doing this as part of work to improve the homepage.

The tag list in the side panel, in my mind, is secondary content and should be loaded async.

* I've moved the tags logic into a `{{tag-list}}` component
* Use ember-concurrency to fetch the tags
* Removed the `setTag` logic and used `{{link-to}}` instead

![taglist](https://user-images.githubusercontent.com/685034/57546532-d5078e00-7354-11e9-966d-dfbb87eed70d.gif)
