### PR TITLE
Validate the comment to prevent empty comment creation.

### DIFF
--- a/app/controllers/article.js
+++ b/app/controllers/article.js
@@ -49,6 +49,17 @@ export default Controller.extend({
     },
   }),
 
+  /**
+   * Validate the new comment to prevent creating empty comments.
+   * @returns {Boolean}
+   */
+  isNewCommentValid: computed('newComment', function() {
+    /**
+     * Make sure the string isn't just whitespace.
+     */
+    return !!this.newComment.trim();
+  }),
+
   actions: {
     async createComment(article, message) {
       await this.store

--- a/app/templates/article.hbs
+++ b/app/templates/article.hbs
@@ -35,7 +35,7 @@
             </div>
             <div class="card-footer">
               <img class="comment-author-img" alt="">
-              <button class="btn btn-sm btn-primary" type="submit">
+              <button class="btn btn-sm btn-primary" type="submit" disabled={{not isNewCommentValid}}>
                 Post Comment
               </button>
             </div>

--- a/tests/unit/controllers/article-test.js
+++ b/tests/unit/controllers/article-test.js
@@ -62,6 +62,7 @@ module('Unit | Controller | article', function(hooks) {
 
   test('`comments` are sorted by `id` in descending order', function(assert) {
     assert.expect(1);
+
     const controller = this.owner.lookup('controller:article');
     controller.set('model', article);
 
@@ -71,6 +72,7 @@ module('Unit | Controller | article', function(hooks) {
 
   test('`articleBody` is markdown converted to HTML safe string', function(assert) {
     assert.expect(1);
+
     const controller = this.owner.lookup('controller:article');
     controller.set('model', article);
 
@@ -81,6 +83,7 @@ module('Unit | Controller | article', function(hooks) {
 
   test('`newComment` tracks string changes and updates when `model` changes', function(assert) {
     assert.expect(3);
+
     const controller = this.owner.lookup('controller:article');
     controller.set('model', article);
 
@@ -97,6 +100,28 @@ module('Unit | Controller | article', function(hooks) {
     controller.set('model', null);
 
     assert.equal(controller.get('newComment'), '', 'should reset to the default when `model` changes');
+  });
+
+  test('`isNewCommentValid` validates the new comment', function(assert) {
+    assert.expect(3);
+
+    const controller = this.owner.lookup('controller:article');
+    controller.set('model', article);
+
+    assert.equal(controller.get('newComment'), '', 'New comment should be an empty string by default');
+    assert.notOk(controller.get('isNewCommentValid'), 'New comment should be invalid because it is an empty string');
+
+    controller.set('newComment', '   ');
+    assert.notOk(
+      controller.get('isNewCommentValid'),
+      'New comment should be invalid because because it only has spaces',
+    );
+
+    controller.set('newComment', ' a ');
+    assert.ok(
+      controller.get('isNewCommentValid'),
+      'New comment should be valid because there a non-space character in the string.',
+    );
   });
 
   test('`createComment` method creates a new comment record', async function(assert) {

--- a/tests/unit/controllers/article-test.js
+++ b/tests/unit/controllers/article-test.js
@@ -112,15 +112,12 @@ module('Unit | Controller | article', function(hooks) {
     assert.notOk(controller.get('isNewCommentValid'), 'New comment should be invalid because it is an empty string');
 
     controller.set('newComment', '   ');
-    assert.notOk(
-      controller.get('isNewCommentValid'),
-      'New comment should be invalid because because it only has spaces',
-    );
+    assert.notOk(controller.get('isNewCommentValid'), 'New comment should be invalid because it only has spaces');
 
     controller.set('newComment', ' a ');
     assert.ok(
       controller.get('isNewCommentValid'),
-      'New comment should be valid because there a non-space character in the string.',
+      'New comment should be valid because there is a non-space character in the string.',
     );
   });
 

--- a/tests/unit/controllers/article-test.js
+++ b/tests/unit/controllers/article-test.js
@@ -103,7 +103,7 @@ module('Unit | Controller | article', function(hooks) {
   });
 
   test('`isNewCommentValid` validates the new comment', function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     const controller = this.owner.lookup('controller:article');
     controller.set('model', article);


### PR DESCRIPTION
This PR disables the comment form submit button if the new comment is invalid.

The new comment validation just checks if the comment is empty or not.