### PR TITLE
Load tags via `query` instead of `findAll`.

### DIFF
--- a/app/components/tag-list.js
+++ b/app/components/tag-list.js
@@ -10,7 +10,11 @@ export default Component.extend({
     this.loadTags.perform();
   },
   loadTags: task(function*() {
-    const tags = yield this.store.findAll('tag', { reload: true });
+    /**
+     * Query for popular tags.
+     * Using findAll would return a live array that would get populated with tags from articles, which may/may-not be popular tags.
+     */
+    const tags = yield this.store.query('tag', {});
     this.set('tags', tags);
   }).drop(),
 });

--- a/tests/integration/components/tag-list-test.js
+++ b/tests/integration/components/tag-list-test.js
@@ -1,15 +1,28 @@
-import { module, test } from 'qunit';
+import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import test from 'ember-sinon-qunit/test-support/test';
 
 module('Integration | Component | tag-list', function(hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
   test('it loads the tags', async function(assert) {
+    assert.expect(2);
+
+    const store = this.owner.lookup('service:store');
+    const querySpy = this.spy(store, 'query');
+
     await render(hbs`{{tag-list}}`);
+
     assert.dom('[data-test-tag]').exists({ count: 7 }, 'All the tags appear');
+
+    /**
+     * Query for popular tags.
+     * Using findAll would return a live array that would get populated with tags from articles, which may/may-not be popular tags.
+     */
+    assert.ok(querySpy.calledOnceWithExactly('tag', {}), 'Should use `store.query` for popular tags.');
   });
 });


### PR DESCRIPTION
Fixes #87.