### PR TITLE
Improved registration flow

### DIFF
--- a/app/components/login-form.hbs
+++ b/app/components/login-form.hbs
@@ -1,6 +1,6 @@
 <h1 class="text-xs-center">Sign in</h1>
 <p class="text-xs-center">
-  <LinkTo @route="login">Need an account?</LinkTo>
+  <LinkTo @route="register" data-test-register-link>Need an account?</LinkTo>
 </p>
 {{#if this.loginErrors}}
   <ul class="error-messages">

--- a/app/components/register-form.hbs
+++ b/app/components/register-form.hbs
@@ -2,7 +2,6 @@
 <p class="text-xs-center">
   <LinkTo @route="login" data-test-login-link>Have an account?</LinkTo>
 </p>
-
 {{#if (not this.user.isValid)}}
   <ul class="error-messages">
     {{#each this.user.errors as |error|}}
@@ -10,18 +9,21 @@
     {{/each}}
   </ul>
 {{/if}}
-
 <form>
   <fieldset class="form-group">
-    <Input class="form-control form-control-lg" type="text" placeholder="Your Name" @value={{this.username}} data-test-register-name/>
+    <Input class="form-control form-control-lg" type="text" placeholder="Your Username" @value={{this.username}}
+      data-test-register-username />
   </fieldset>
   <fieldset class="form-group">
-    <Input class="form-control form-control-lg" type="text" placeholder="Email" @value={{this.email}} data-test-register-email/>
+    <Input class="form-control form-control-lg" type="text" placeholder="Email" @value={{this.email}}
+      data-test-register-email />
   </fieldset>
   <fieldset class="form-group">
-    <Input class="form-control form-control-lg" type="password" placeholder="Password" @value={{this.password}} data-test-register-password/>
+    <Input class="form-control form-control-lg" type="password" placeholder="Password" @value={{this.password}}
+      data-test-register-password />
   </fieldset>
-  <button class="btn btn-lg btn-primary pull-xs-right" {{on "click" this.submit}} disabled={{or (not this.username) (not this.email) ( not this.password)}} type="button" data-test-register-button>
+  <button class="btn btn-lg btn-primary pull-xs-right" {{on "click" this.submit}}
+    disabled={{or (not this.username) (not this.email) ( not this.password)}} type="button" data-test-register-button>
     Sign up
   </button>
 </form>

--- a/app/components/register-form.hbs
+++ b/app/components/register-form.hbs
@@ -1,6 +1,6 @@
 <h1 class="text-xs-center">Sign up</h1>
 <p class="text-xs-center">
-  <LinkTo @route="login">Have an account?</LinkTo>
+  <LinkTo @route="login" data-test-login-link>Have an account?</LinkTo>
 </p>
 
 {{#if (not this.user.isValid)}}
@@ -13,15 +13,15 @@
 
 <form>
   <fieldset class="form-group">
-    <Input class="form-control form-control-lg" type="text" placeholder="Your Name" @value={{this.username}} />
+    <Input class="form-control form-control-lg" type="text" placeholder="Your Name" @value={{this.username}} data-test-register-name/>
   </fieldset>
   <fieldset class="form-group">
-    <Input class="form-control form-control-lg" type="text" placeholder="Email" @value={{this.email}} />
+    <Input class="form-control form-control-lg" type="text" placeholder="Email" @value={{this.email}} data-test-register-email/>
   </fieldset>
   <fieldset class="form-group">
-    <Input class="form-control form-control-lg" type="password" placeholder="Password" @value={{this.password}} />
+    <Input class="form-control form-control-lg" type="password" placeholder="Password" @value={{this.password}} data-test-register-password/>
   </fieldset>
-  <button class="btn btn-lg btn-primary pull-xs-right" {{on "click" this.submit}} disabled={{or (not this.username) (not this.email) ( not this.password)}} type="button">
+  <button class="btn btn-lg btn-primary pull-xs-right" {{on "click" this.submit}} disabled={{or (not this.username) (not this.email) ( not this.password)}} type="button" data-test-register-button>
     Sign up
   </button>
 </form>

--- a/app/components/register-form.js
+++ b/app/components/register-form.js
@@ -4,18 +4,13 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class RegisterFormComponent extends Component {
-  @tracked username;
-  @tracked email;
-  @tracked password;
-  @tracked user;
+  @tracked username = '';
+  @tracked email = '';
+  @tracked password = '';
+  @tracked user = null;
 
   @service session;
   @service router;
-
-  username = '';
-  email = '';
-  password = '';
-  user = null;
 
   @action
   async submit(e) {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -45,8 +45,8 @@ export default class SessionService extends Service {
     try {
       await user.save();
       this.setToken(user.token);
-    } catch {
-      // Registration returned errors
+    } catch (e) {
+      console.error(e);
     } finally {
       this.user = user;
     }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -46,6 +46,7 @@ export default class SessionService extends Service {
       await user.save();
       this.setToken(user.token);
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error(e);
     } finally {
       this.user = user;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -100,7 +100,10 @@ export default function() {
   /**
    * User registration
    */
-  // this.post('/users', (schema, request) => {});
+  this.post('/users', (schema, request) => {
+    const attrs = JSON.parse(request.requestBody).user;
+    return schema.users.findBy({ email: attrs.email });
+  });
 
   /**
    * Get current user

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -28,4 +28,13 @@ module('Acceptance | login', function(hooks) {
     assert.dom('[data-test-nav-new-post]').exists('Logged in nav is shown');
     assert.dom('[data-test-nav-sign-up]').doesNotExist('Logged out nav is not shown');
   });
+
+  test('visiting /login has link to /register', async function(assert) {
+    await visit('/login');
+
+    await click('[data-test-register-link]');
+    await settled();
+
+    assert.equal(currentURL(), '/register', 'URL after click is Register');
+  });
 });

--- a/tests/acceptance/register-test.js
+++ b/tests/acceptance/register-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import faker from 'faker';
+import { visit, currentURL, fillIn, click, settled } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { setupLoggedOutUser } from '../helpers/user';
+
+module('Acceptance | register', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupLoggedOutUser(hooks);
+
+  test('successful registration', async function(assert) {
+    const user = {
+      name: 'Test User',
+      email: faker.internet.email(),
+      password: 'password123',
+    };
+
+    await visit('/register');
+
+    await fillIn('[data-test-register-name]', user.name);
+    await fillIn('[data-test-register-email]', user.email);
+    await fillIn('[data-test-register-password]', user.password);
+
+    await click('[data-test-register-button]');
+    await settled();
+
+    assert.equal(currentURL(), '/', 'URL after login is Home');
+    assert.dom('[data-test-nav-username]').hasText(user.name, 'Logged in username is shown');
+    assert.dom('[data-test-nav-new-post]').exists('Logged in nav is shown');
+    assert.dom('[data-test-nav-sign-up]').doesNotExist('Logged out nav is not shown');
+  });
+
+  test('visiting /register has link to /login', async function(assert) {
+    await visit('/register');
+
+    await click('[data-test-login-link]');
+    await settled();
+
+    assert.equal(currentURL(), '/login', 'URL after click is Login');
+  });
+});

--- a/tests/acceptance/register-test.js
+++ b/tests/acceptance/register-test.js
@@ -11,15 +11,16 @@ module('Acceptance | register', function(hooks) {
   setupLoggedOutUser(hooks);
 
   test('successful registration', async function(assert) {
-    const user = {
+    const user = this.server.create('user', {
       name: 'Test User',
+      username: 'test_user',
       email: faker.internet.email(),
       password: 'password123',
-    };
+    });
 
     await visit('/register');
 
-    await fillIn('[data-test-register-name]', user.name);
+    await fillIn('[data-test-register-username]', user.username);
     await fillIn('[data-test-register-email]', user.email);
     await fillIn('[data-test-register-password]', user.password);
 
@@ -27,7 +28,7 @@ module('Acceptance | register', function(hooks) {
     await settled();
 
     assert.equal(currentURL(), '/', 'URL after login is Home');
-    assert.dom('[data-test-nav-username]').hasText(user.name, 'Logged in username is shown');
+    assert.dom('[data-test-nav-username]').hasText(user.username, 'Logged in username is shown');
     assert.dom('[data-test-nav-new-post]').exists('Logged in nav is shown');
     assert.dom('[data-test-nav-sign-up]').doesNotExist('Logged out nav is not shown');
   });


### PR DESCRIPTION
- Previously the sign-in page incorrectly linked back to itself instead of the sign-up page.
- Bug prevented successful registration
```
Error: Assertion Failed: You attempted to update [object Object].user to "<ember-realworld@model:user::ember323:null>", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.
```
  